### PR TITLE
Added try except block to catch ssl errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
+!.env.example
 .venv
 env/
 venv/


### PR DESCRIPTION
- If IGNORE_SSL_ERRORS is true, then silence SSL verification & continue. 
- If IGNORE_SSL_ERRORS is false, then raise the error with custom message. 
- Added verbose option to assist with reducing output and allowing for verbose logging if desired. 
- If IGNORE_SSL_ERRORS is false, and --verbose is specified, then print the exception.

Fixes #58
Fixes #60
