### PR TITLE
Remove Repo init from __init__

### DIFF
--- a/gitcmd.py
+++ b/gitcmd.py
@@ -11,7 +11,6 @@ class GitCMD:
         self.url = args.url
         self.repo_path = repo_path
         self.branch = args.branch
-        self.repo = Repo()
         self.cwd = os.getcwd()
         
         if os.path.isdir(self.repo_path):

--- a/gitcmd.py
+++ b/gitcmd.py
@@ -11,6 +11,7 @@ class GitCMD:
         self.url = args.url
         self.repo_path = repo_path
         self.branch = args.branch
+#        self.repo = Repo()
         self.cwd = os.getcwd()
         
         if os.path.isdir(self.repo_path):
@@ -42,4 +43,3 @@ class GitCMD:
             settings.handle.exception("GitCommandError", self.url, git_error)
         except Exception as git_error:
             settings.handle.exception("Exception", 'Git Repository Error', git_error)
-

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -53,7 +53,7 @@ def getFiles(vendors=None):
     
     files = []
     discoveredVendors = []
-    base_path = './repo/device-types/'
+    base_path = f'{settings.REPO_PATH}/device-types/'
     if vendors:
         for r, d, f in os.walk(base_path):
             for folder in d:
@@ -88,7 +88,7 @@ def get_files_modules(vendors=None):
 
     files = []
     discoveredVendors = []
-    base_path = './repo/module-types/'
+    base_path = f'{settings.REPO_PATH}/module-types/'
     if vendors:
         for r, d, f in os.walk(base_path):
             for folder in d:

--- a/settings.py
+++ b/settings.py
@@ -12,7 +12,7 @@ REPO_BRANCH = os.getenv("REPO_BRANCH", default="master")
 NETBOX_URL = os.getenv("NETBOX_URL")
 NETBOX_TOKEN = os.getenv("NETBOX_TOKEN")
 IGNORE_SSL_ERRORS = (os.getenv("IGNORE_SSL_ERRORS", default="False") == "True")
-REPO_PATH = "./repo"
+REPO_PATH = f"{os.path.dirname(os.path.realpath(__file__))}/repo"
 
 # optionally load vendors through a comma separated list as env var
 VENDORS = list(filter(None, os.getenv("VENDORS", "").split(",")))


### PR DESCRIPTION
Initializing the repository from init, before the path has been updated, will lead an exception when the script is not run directly from the repository.

Example exception (during the run in an ansible playbook):
git.exc.InvalidGitRepositoryError: /home/ansible

I ran the script successfully directy from the folder as well as from outside with the line removed:
`# python3 nb-dt-import.py`
`# /opt/Netbox-Device-Type-Library-Import/.venv/bin/python3 /opt/Netbox-Device-Type-Library-Import/nb-dt-import.py`