### PR TITLE
Add more info to failed device_type creations

### DIFF
--- a/netbox_api.py
+++ b/netbox_api.py
@@ -89,7 +89,9 @@ class NetBox:
                     self.handle.verbose_log(f'Device Type Created: {dt.manufacturer.name} - '
                         + f'{dt.model} - {dt.id}')
                 except pynetbox.RequestError as e:
-                    self.handle.log(e.error)
+                    self.handle.log(f'Error {e.error} creating device type:'
+                                    f' {device_type["manufacturer"]["name"]} {device_type["model"]}')
+                    continue
 
             if "interfaces" in device_type:
                 self.device_types.create_interfaces(device_type["interfaces"], dt.id)

--- a/repo.py
+++ b/repo.py
@@ -75,7 +75,7 @@ class DTLRepo:
         vendor_dirs = os.listdir(base_path)
 
         for folder in [vendor for vendor in vendor_dirs if not vendors or vendor.casefold() in vendors]:
-            if folder.casefold() is not "testing":
+            if folder.casefold() != "testing":
                 discovered_vendors.append({'name': folder,
                                            'slug': self.slug_format(folder)})
                 for extension in self.yaml_extensions:


### PR DESCRIPTION
This adds the manufacturer and model to failed device_type creations and then continues with others.

Previously, the script would throw an exception, because the 'dt' wasn't actually created, but tried to continue working with it.

I have also fixed the small issue in repo.py we talked about.